### PR TITLE
Fix : exportToCanvas() example

### DIFF
--- a/dev-docs/docs/@excalidraw/excalidraw/api/utils/export.mdx
+++ b/dev-docs/docs/@excalidraw/excalidraw/api/utils/export.mdx
@@ -90,7 +90,7 @@ function App() {
         <img src={canvasUrl} alt="" />
       </div>
       <div style={{ height: "400px" }}>
-        <Excalidraw ref={(api) => setExcalidrawAPI(api)}
+        <Excalidraw excalidrawAPI={(api) => setExcalidrawAPI(api)}
 />
       </div>
     </>


### PR DESCRIPTION
In the exportToCanvas() example, the ref prop is passed to the <Excalidraw /> component, which is wrong because you can't pass the ref prop to a function component, and in this example we want to save the excalidrawAPI in the state, so we need to pass the excalidrawAPI prop instead of ref.